### PR TITLE
Orders

### DIFF
--- a/backend/games/.flake8
+++ b/backend/games/.flake8
@@ -1,6 +1,4 @@
 [flake8]
-exclude =
-    venv,
-    migrations
+exclude = venv, migrations, __init__.py
 max-line-length=100
 ignore=F401

--- a/backend/games/base/choices.py
+++ b/backend/games/base/choices.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+
+class BaseTextChoices(models.TextChoices):
+    @classmethod
+    def max_length(cls):
+        return max([len(v) for v in cls.values])
+
+
+class CurrencyChoices(BaseTextChoices):
+    RUB = "RUB", "Rub"
+    USD = "USD", "Usd"
+    KZT = "KZT", "Kzt"
+    EUR = "EUR", "Eur"
+
+
+class OrderStatusChoices(BaseTextChoices):
+    WAITING_PAYMENT = "WAITING_PAYMENT", "Waiting Payment"
+    COMPLETED = "COMPLETED", "Completed"
+    CANCELED = "CANCELED", "Canceled"
+    REFUND_REQUESTED = "REFUND_REQUESTED", "Refund Requested"
+    REFUNDED = "REFUNDED", "Refunded"

--- a/backend/games/base/model_fields.py
+++ b/backend/games/base/model_fields.py
@@ -1,0 +1,38 @@
+from typing import Union
+
+from django.db.models import (
+    CharField,
+    DecimalField,
+    IntegerChoices,
+    PositiveSmallIntegerField,
+    TextChoices,
+)
+
+
+def get_field_from_choices(
+    label, choices_class: Union[IntegerChoices, TextChoices], **kwargs
+) -> Union[PositiveSmallIntegerField, CharField]:
+    """Get django model field from choices class"""
+
+    if issubclass(choices_class, IntegerChoices):
+        return PositiveSmallIntegerField(label, choices=choices_class.choices, **kwargs)
+    elif issubclass(choices_class, TextChoices):
+        if "max_length" in kwargs:
+            max_length = kwargs.pop("max_length")
+        else:
+            max_length = max([len(v) for v in choices_class.values])
+
+        return CharField(
+            label, choices=choices_class.choices, max_length=max_length, **kwargs
+        )
+    else:
+        raise AssertionError(
+            "Unexpected choice class. Must be of IntegerChoices or TextChoices"
+        )
+
+
+class AmountField(DecimalField):
+    def __init__(
+        self, verbose_name=None, name=None, max_digits=10, decimal_places=2, **kwargs
+    ):
+        super().__init__(verbose_name, name, max_digits, decimal_places, **kwargs)

--- a/backend/games/base/serializers.py
+++ b/backend/games/base/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+from django.db.models import Model
+
+
+class ChoiceAsDictField(serializers.ChoiceField):
+    """
+    Serializes field with choices as a dictionary to provide both value and label of the choice.
+    """
+
+    def to_representation(self, value):
+        if value in ("", None):
+            return None
+        return {"id": value, "label": self.choices[value]}
+
+
+class BaseModelSerializer(serializers.ModelSerializer):
+    """
+    A base ModelSerializer used by default in the project. Extends default ModelSerializer by:
+    * using custom serialization for choice fields
+    """
+    serializer_choice_field = ChoiceAsDictField
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if (
+            getattr(self.Meta, "fields", None) is None
+            and getattr(self.Meta, "exclude", None) is None
+        ):
+            setattr(self.Meta, "fields", "__all__")
+
+    class Meta:
+        model: Model

--- a/backend/games/base/viewsets.py
+++ b/backend/games/base/viewsets.py
@@ -1,0 +1,46 @@
+from djangorestframework_camel_case.parser import (
+    CamelCaseFormParser,
+    CamelCaseMultiPartParser,
+)
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+
+def choices_to_dict(choices):
+    if choices:
+        return [{"id": k, "label": v} for k, v in choices]
+    else:
+        return None
+
+
+class BaseModelViewSet(viewsets.ModelViewSet):
+    """
+    Extends default ModelViewSet by:
+    * custom choices action to give info of model allowed choices
+    * auto definition serializer many param
+    """
+    yasg_parser_classes = [CamelCaseFormParser, CamelCaseMultiPartParser]
+
+    @action(methods=["GET"], detail=False)
+    def choices(self, request):
+        """ Get all available values for choice fields """
+        qs = self.get_queryset()
+        model_fields = qs.model._meta.fields
+
+        field_choices = {
+            field.name: choices_to_dict(field.choices)
+            for field in model_fields
+            if hasattr(field, "choices") and field.choices is not None
+        }
+
+        return Response(field_choices)
+
+    def get_serializer(self, *args, **kwargs):
+        if isinstance(kwargs.get("data", {}), list):
+            kwargs["many"] = True
+            serializer = super().get_serializer(*args, **kwargs)
+            serializer.is_valid()
+        else:
+            serializer = super().get_serializer(*args, **kwargs)
+        return serializer

--- a/backend/games/finance/models.py
+++ b/backend/games/finance/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/backend/games/finance/models/__init__.py
+++ b/backend/games/finance/models/__init__.py
@@ -1,0 +1,1 @@
+from .orders import *

--- a/backend/games/finance/models/orders.py
+++ b/backend/games/finance/models/orders.py
@@ -1,0 +1,64 @@
+from django.db import models
+
+from base.model_fields import get_field_from_choices, AmountField
+
+from base.choices import CurrencyChoices, OrderStatusChoices
+
+
+class Order(models.Model):
+    created_by = models.UUIDField("Created By UUID")
+    currency = get_field_from_choices("Currency", CurrencyChoices, default=CurrencyChoices.RUB)
+    total_amount = AmountField("Total Amount")
+    total_discount = models.PositiveSmallIntegerField("Total Discount (%)")
+    payment_amount = AmountField("Total Amount")
+    created_at = models.DateTimeField("Created At", auto_now_add=True)
+    payment_id = models.CharField("Payment Id", max_length=128, null=True)
+    is_paid = models.BooleanField("Is Paid", default=False)
+    gift_recipient = models.UUIDField("Recipient UUID")
+
+    class Meta:
+        db_table = "order"
+
+
+class OrderStatus(models.Model):
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name="statuses")
+    status = get_field_from_choices(
+        "Status", OrderStatusChoices, default=OrderStatusChoices.WAITING_PAYMENT
+    )
+    from_dttm = models.DateTimeField("From dttm", auto_now_add=True)
+
+    class Meta:
+        db_table = "order_status"
+        ordering = ("-from_dttm",)
+
+
+class OrderOfferProduct(models.Model):
+    product_id = models.UUIDField("Product UUID", primary_key=True)
+
+    class Meta:
+        db_table = "order_offer_product"
+
+
+class OrderOffer(models.Model):
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name="offers")
+    offer_id = models.UUIDField("Offer ID")
+    price_currency = get_field_from_choices(
+        "Currency", CurrencyChoices, default=CurrencyChoices.RUB
+    )
+    price_amount = AmountField("Price Amount")
+    sale_discount = models.PositiveSmallIntegerField("Total Discount (%)")
+    products = models.ManyToManyField(
+        OrderOfferProduct, through="OrderOfferProducts", related_name="offers"
+    )
+
+    class Meta:
+        db_table = "order_offer"
+
+
+class OrderOfferProducts(models.Model):
+    offer = models.ForeignKey(OrderOffer, on_delete=models.CASCADE)
+    product = models.ForeignKey(OrderOfferProduct, on_delete=models.PROTECT)
+
+    class Meta:
+        db_table = "order_offer_products"
+        unique_together = ("offer", "product")


### PR DESCRIPTION
- Add finance/orders models
- Exclude flake8 __init__.py

Added:
    - BaseTextChoices class. It uses instead of including choices class inside model
    - get_field_from_choice func. It uses for getting models.ChoiceField from BaseTextChoices (IntegerChoices) child class.
    - BaseModelSerializer. It automatically fills Meta.fields if it has not been provided. It transforms choices field to dict.
    - BaseModelViewSet. Custom action choices to give info of model allowed choices. Auto definition serializer many param